### PR TITLE
Fixed support for modded blocks

### DIFF
--- a/src/main/java/com/starl0stgaming/gregicalitystarbound/GregicalityStarbound.java
+++ b/src/main/java/com/starl0stgaming/gregicalitystarbound/GregicalityStarbound.java
@@ -4,14 +4,16 @@ import com.starl0stgaming.gregicalitystarbound.api.configuration.GCSBConfigHandl
 import com.starl0stgaming.gregicalitystarbound.api.configuration.space.SpaceConfigHandler;
 import com.starl0stgaming.gregicalitystarbound.common.CommonProxy;
 import com.starl0stgaming.gregicalitystarbound.common.space.SpaceController;
+import gregtech.GTInternalTags;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.lwjgl.input.Keyboard;
 
-@Mod(name = GregicalityStarbound.NAME, modid = GregicalityStarbound.MODID)
+@Mod(name = GregicalityStarbound.NAME, modid = GregicalityStarbound.MODID, dependencies = GTInternalTags.DEP_VERSION_STRING)
 public class GregicalityStarbound {
 
 
@@ -39,8 +41,10 @@ public class GregicalityStarbound {
         keyBinding = new KeyBinding("key.gregicalitystarbound.test", Keyboard.KEY_P,"key.gregicalitystarbound.category");
 
         ClientRegistry.registerKeyBinding(keyBinding);
+    }
 
-
-
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event) {
+        proxy.load();
     }
 }

--- a/src/main/java/com/starl0stgaming/gregicalitystarbound/common/CommonProxy.java
+++ b/src/main/java/com/starl0stgaming/gregicalitystarbound/common/CommonProxy.java
@@ -29,12 +29,16 @@ public class CommonProxy {
 
     public void preLoad() {
         ModDimension.init();
-        GregicalityStarbound.SPACE_CONTROLLER.initializeSpace();
     }
 
+    public void load() {
+
+    }
 
     @SubscribeEvent
     public static void registerBiomes(RegistryEvent.Register<Biome> event) {
+        GregicalityStarbound.SPACE_CONTROLLER.initializeSpace();
+
         IForgeRegistry<Biome> registry = event.getRegistry();
 
         registry.registerAll(ModDimension.BIOMES.toArray(new Biome[0]));


### PR DESCRIPTION
# What
Fixed not being able to use modded blocks for dimensions/biomes

# Implementation
Planet/Dimension registration now happens later during loading (when biomes are registered)